### PR TITLE
Render VCL using Magento\Framework template engine

### DIFF
--- a/Model/TemplateFactory.php
+++ b/Model/TemplateFactory.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Elgentos\VarnishExtended\Model;
+
+use Magento\Framework\App\ObjectManager;
+use Magento\Framework\Filter\DirectiveProcessorInterface;
+use Magento\Framework\Filter\Template;
+use Magento\Framework\Filter\Template\FilteringDepthMeter;
+use Magento\Framework\Filter\Template\SignatureProvider;
+use Magento\Framework\Filter\VariableResolverInterface;
+use Magento\Framework\Stdlib\StringUtils;
+
+class TemplateFactory
+{
+    /**
+     * @param StringUtils $stringUtils
+     * @param DirectiveProcessorInterface[] $directiveProcessors
+     * @param VariableResolverInterface $variableResolver
+     * @param SignatureProvider $signatureProvider
+     * @param FilteringDepthMeter $filteringDepthMeter
+     */
+    public function __construct(
+        private readonly StringUtils               $stringUtils,
+        private readonly array                     $directiveProcessors,
+        private readonly VariableResolverInterface $variableResolver,
+        private readonly SignatureProvider         $signatureProvider,
+        private readonly FilteringDepthMeter       $filteringDepthMeter,
+    ) {}
+
+    public function create(array $variables = []): Template
+    {
+        $arguments = [
+            'string' => $this->stringUtils,
+            'variableResolver' => $this->variableResolver,
+            'signature' => $this->signatureProvider,
+            'filteringDepth' => $this->filteringDepthMeter,
+            'directiveProcessors' => $this->directiveProcessors,
+            'variables' => $variables,
+        ];
+        return ObjectManager::getInstance()->create(Template::class, $arguments);
+    }
+}

--- a/Model/Varnish/VCLGenerator.php
+++ b/Model/Varnish/VCLGenerator.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Elgentos\VarnishExtended\Model\Varnish;
+
+use Elgentos\VarnishExtended\Model\TemplateFactory;
+use Magento\PageCache\Model\VclTemplateLocatorInterface;
+
+class VCLGenerator extends \Magento\PageCache\Model\Varnish\VclGenerator
+{
+    public function __construct(
+        private readonly TemplateFactory $templateFactory,
+        private readonly VclTemplateLocatorInterface $vclTemplateLocator,
+        private readonly string $backendHost,
+        private readonly string $backendPort,
+        private readonly array $accessList,
+        private readonly string $gracePeriod,
+        private readonly string $sslOffloadedHeader,
+        private readonly array $designExceptions = []
+    ) {
+        parent::__construct(
+            $vclTemplateLocator,
+            $backendHost,
+            $backendPort,
+            $accessList,
+            $gracePeriod,
+            $sslOffloadedHeader
+        );
+    }
+
+    public function generateVcl($version, $inputFile = null)
+    {
+        $templateRenderer = $this->templateFactory->create($this->getVariables());
+        $template = $this->vclTemplateLocator->getTemplate($version, $inputFile);
+        return $templateRenderer->filter($template);
+    }
+
+    public function getVariables(): array
+    {
+        return [
+            'host' => $this->backendHost,
+            'port' => $this->backendPort,
+            'ips' => $this->getTransformedAccessList(),
+            'grace_period' => $this->gracePeriod,
+            'ssl_offloaded_header' => $this->sslOffloadedHeader,
+            'design_exceptions_code' => $this->getRegexForDesignExceptions()
+        ];
+    }
+
+    /**
+     * Get regexs for design exceptions
+     * Different browser user-agents may use different themes
+     * Varnish supports regex with internal modifiers only so
+     * we have to convert "/pattern/iU" into "(?Ui)pattern"
+     *
+     * @return string
+     */
+    private function getRegexForDesignExceptions(): string
+    {
+        $result = '';
+        $tpl = "%s (req.http.user-agent ~ \"%s\") {\n" . "        hash_data(\"%s\");\n" . "    }";
+
+        if (!$this->designExceptions) {
+            return $result;
+        }
+
+        $rules = array_values($this->designExceptions);
+        foreach ($rules as $i => $rule) {
+            if (preg_match('/^[\W]{1}(.*)[\W]{1}(\w+)?$/', $rule['regexp'] ?? '', $matches)) {
+                if (!empty($matches[2])) {
+                    $pattern = sprintf("(?%s)%s", $matches[2], $matches[1]);
+                } else {
+                    $pattern = $matches[1];
+                }
+                $if = $i == 0 ? 'if' : ' elsif';
+                $result .= sprintf($tpl, $if, $pattern, $rule['value']);
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * Get IPs access list that can purge Varnish configuration for config file generation
+     *
+     * Tansform it to appropriate view
+     *
+     * acl purge{
+     *  "127.0.0.1";
+     *  "127.0.0.2";
+     *
+     * @return string
+     */
+    private function getTransformedAccessList(): string
+    {
+        $tpl = "    \"%s\";";
+        $result = array_reduce(
+            $this->accessList,
+            function ($ips, $ip) use ($tpl) {
+                return $ips . sprintf($tpl, trim($ip)) . "\n";
+            },
+            ''
+        );
+
+        return rtrim($result ?: '', "\n");
+    }
+}

--- a/Model/Varnish/VCLTemplateLocator.php
+++ b/Model/Varnish/VCLTemplateLocator.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Elgentos\VarnishExtended\Model\Varnish;
+
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\Exception\FileSystemException;
+use Magento\Framework\Module\Dir;
+use Magento\Framework\Module\Dir\Reader;
+use Magento\Framework\Filesystem\DirectoryList;
+use Magento\Framework\Filesystem\Directory\ReadFactory;
+use Magento\PageCache\Model\Config as BaseConfig;
+use Magento\PageCache\Model\VclTemplateLocatorInterface;
+use Magento\PageCache\Exception\UnsupportedVarnishVersion;
+
+use \Magento\PageCache\Model\Varnish\VclTemplateLocator as BaseLocator;
+
+class VCLTemplateLocator implements VclTemplateLocatorInterface
+{
+    private array $supportedVarnishVersions = [
+        BaseLocator::VARNISH_SUPPORTED_VERSION_6 => BaseLocator::VARNISH_6_CONFIGURATION_PATH,
+        BaseLocator::VARNISH_SUPPORTED_VERSION_7 => BaseConfig::VARNISH_7_CONFIGURATION_PATH,
+    ];
+
+    public function __construct(
+        private readonly Reader $reader,
+        private readonly ReadFactory $readFactory,
+        private readonly ScopeConfigInterface $scopeConfig,
+        private readonly DirectoryList $directoryList
+    ) {
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getTemplate($version, $inputFile = null)
+    {
+        if ($inputFile) {
+            $reader = $this->readFactory->create($this->directoryList->getRoot());
+            return $reader->readFile($inputFile);
+        }
+
+        $template = null;
+        foreach (['Elgentos_VarnishExtended', 'Magento_PageCache'] as $module) {
+            $moduleEtcPath  = $this->reader->getModuleDir(Dir::MODULE_ETC_DIR, $module);
+            $configFilePath = $moduleEtcPath . '/' . $this->scopeConfig->getValue($this->getVclTemplatePath($version));
+            $directoryRead  = $this->readFactory->create($moduleEtcPath);
+            $configFilePath = $directoryRead->getRelativePath($configFilePath);
+            try {
+                printf("VCL template: %s/%s\n", $moduleEtcPath, $configFilePath);
+                $template = $directoryRead->readFile($configFilePath);
+            } catch (FileSystemException $e) {
+                continue;
+            }
+            // No exception, so we can continue
+            break;
+        }
+
+        if ($template === null) {
+            throw new UnsupportedVarnishVersion(__("Failed to find VCL template for version {$version}"));
+        }
+
+        return $template;
+    }
+
+    /**
+     * Get VCL template config path
+     *
+     * @param int $version Varnish version
+     * @return string
+     * @throws UnsupportedVarnishVersion
+     */
+    private function getVclTemplatePath($version)
+    {
+        if (!isset($this->supportedVarnishVersions[$version])) {
+            throw new UnsupportedVarnishVersion(__('Unsupported varnish version'));
+        }
+
+        return $this->supportedVarnishVersions[$version];
+    }
+}

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -4,5 +4,19 @@
     <type name="Magento\PageCache\Model\Varnish\VclGenerator">
         <plugin name="AddReplacements" type="Elgentos\VarnishExtended\Plugin\AddReplacementsPlugin"/>
     </type>
-    <preference for="Magento\PageCache\Console\Command\GenerateVclCommand" type="Elgentos\VarnishExtended\Console\Command\GenerateVclCommand"/>
+    <type name="Elgentos\VarnishExtended\Model\TemplateFactory">
+        <arguments>
+            <argument name="directiveProcessors" xsi:type="array">
+                <item name="if" xsi:type="object">Magento\Framework\Filter\DirectiveProcessor\IfDirective</item>
+                <item name="for" xsi:type="object">Magento\Framework\Filter\DirectiveProcessor\ForDirective</item>
+                <item name="var" xsi:type="object">Magento\Framework\Filter\DirectiveProcessor\VarDirective</item>
+            </argument>
+        </arguments>
+    </type>
+    <preference for="Magento\PageCache\Console\Command\GenerateVclCommand"
+                type="Elgentos\VarnishExtended\Console\Command\GenerateVclCommand"/>
+    <preference for="Magento\PageCache\Model\Varnish\VclGenerator"
+                type="Elgentos\VarnishExtended\Model\Varnish\VCLGenerator"/>
+    <preference for="Magento\PageCache\Model\VclTemplateLocatorInterface"
+                type="Elgentos\VarnishExtended\Model\Varnish\VCLTemplateLocator"/>
 </config>

--- a/etc/varnish6.vcl
+++ b/etc/varnish6.vcl
@@ -1,0 +1,260 @@
+# Optimized VCL for Magento 2 with Xkey support
+
+vcl 4.1;
+
+import std;
+import cookie;
+import xkey;
+
+# The minimal Varnish version is 6.0
+# For SSL offloading, pass the following header in your proxy server or load balancer: '{{var ssl_offloaded_header }}: https'
+
+backend default {
+    .host = "{{var host}}";
+    .port = "{{var port}}";
+    .first_byte_timeout = 600s;
+    .probe = {
+        .url = "/health_check.php";
+        .timeout = 2s;
+        .interval = 5s;
+        .window = 10;
+        .threshold = 5;
+   }
+}
+
+acl purge {
+{{var ips}}
+}
+
+sub vcl_recv {
+    # Remove empty query string parameters
+    # e.g.: www.example.com/index.html?
+    if (req.url ~ "\?$") {
+        set req.url = regsub(req.url, "\?$", "");
+    }
+
+    # Remove port number from host header if set
+    if (req.http.Host ~ ":[0-9]+$") {
+        set req.http.Host = regsub(req.http.Host, ":[0-9]+$", "");
+    }
+
+    # Sorts query string parameters alphabetically for cache normalization purposes, only when there are multiple parameters
+    if (req.url ~ "\?.+&.+") {
+        set req.url = std.querysort(req.url);
+    }
+
+    # Reduce grace to the configured setting if the backend is healthy
+    # In case of an unhealthy backend, the original grace is used
+    if (std.healthy(req.backend_hint)) {
+        set req.grace = {{var grace_period}}s;
+    }
+
+    # Purge logic to remove objects from the cache
+    # Tailored to Magento's cache invalidation mechanism
+    # The X-Magento-Tags-Pattern value is matched to the tags in the X-Magento-Tags header
+    # If X-Magento-Tags-Pattern is not set, a URL-based purge is executed
+    if (req.method == "PURGE") {
+        if (client.ip !~ purge) {
+            return (synth(405));
+        }
+
+        # If the X-Magento-Tags-Pattern header is not set, just use regular URL-based purge
+        if (!req.http.X-Magento-Tags-Pattern) {
+            return (purge);
+        }
+
+        # Full Page Cache flush
+        if (req.http.X-Magento-Tags-Pattern == ".*") {
+            if (0) { # CONFIGURABLE: soft purge
+                set req.http.n-gone = xkey.softpurge("all");
+            } else {
+                set req.http.n-gone = xkey.purge("all");
+            }
+            return (synth(200, "Invalidated " + req.http.n-gone + " objects - full flush"));
+        } elseif (req.http.X-Magento-Tags-Pattern) {
+            # replace "((^|,)cat_c(,|$))|((^|,)cat_p(,|$))" to be "cat_c,cat_p"
+            set req.http.X-Magento-Tags-Pattern = regsuball(req.http.X-Magento-Tags-Pattern, "[^a-zA-Z0-9_-]+" ,",");
+            set req.http.X-Magento-Tags-Pattern = regsuball(req.http.X-Magento-Tags-Pattern, "(^,*)|(,*$)" ,"");
+            if ( 1 ) { # CONFIGURABLE: Use softpurge
+                set req.http.n-gone = xkey.softpurge(req.http.X-Magento-Tags-Pattern);
+            } else {
+                set req.http.n-gone = xkey.purge(req.http.X-Magento-Tags-Pattern);
+            }
+            return (synth(200, "Invalidated " + req.http.n-gone + " objects"));
+        }
+
+        return (synth(200, "Purged"));
+    }
+
+    if (req.method != "GET" &&
+        req.method != "HEAD" &&
+        req.method != "PUT" &&
+        req.method != "POST" &&
+        req.method != "PATCH" &&
+        req.method != "TRACE" &&
+        req.method != "OPTIONS" &&
+        req.method != "DELETE") {
+          return (pipe);
+    }
+
+    # We only deal with GET and HEAD by default
+    if (req.method != "GET" && req.method != "HEAD") {
+        return (pass);
+    }
+
+    # Bypass health check requests
+    if (req.url == "/health_check.php") {
+        return (pass);
+    }
+
+    # Collapse multiple cookie headers into one
+    std.collect(req.http.Cookie, ";");
+
+    # Parse the cookie header
+    cookie.parse(req.http.cookie);
+
+    # Add support for Prismic preview functionality
+    # TODO MAKE CONFIGURABLE, DO NOT HARD-CODE PRISMIC HOST
+    if (cookie.isset("io.prismic.preview")) {
+        return (pass);
+    }
+
+    # Remove all marketing get parameters to minimize the cache objects
+    # TODO MAKE CONFIGURABLE
+    if (req.url ~ "(\?|&)(_branch_match_id|srsltid|_bta_c|_bta_tid|_ga|_gl|_ke|_kx|campid|cof|customid|cx|dclid|dm_i|ef_id|epik|fbclid|gad_source|gbraid|gclid|gclsrc|gdffi|gdfms|gdftrk|hsa_acc|hsa_ad|hsa_cam|hsa_grp|hsa_kw|hsa_mt|hsa_net|hsa_src|hsa_tgt|hsa_ver|ie|igshid|irclickid|matomo_campaign|matomo_cid|matomo_content|matomo_group|matomo_keyword|matomo_medium|matomo_placement|matomo_source|mc_cid|mc_eid|mkcid|mkevt|mkrid|mkwid|msclkid|mtm_campaign|mtm_cid|mtm_content|mtm_group|mtm_keyword|mtm_medium|mtm_placement|mtm_source|nb_klid|ndclid|origin|pcrid|piwik_campaign|piwik_keyword|piwik_kwd|pk_campaign|pk_keyword|pk_kwd|redirect_log_mongo_id|redirect_mongo_id|rtid|sb_referer_host|ScCid|si|siteurl|s_kwcid|sms_click|sms_source|sms_uph|toolid|trk_contact|trk_module|trk_msg|trk_sid|ttclid|twclid|utm_campaign|utm_content|utm_creative_format|utm_id|utm_marketing_tactic|utm_medium|utm_source|utm_source_platform|utm_term|wbraid|yclid|zanpid|mc_[a-z]+|utm_[a-z]+|_bta_[a-z]+)=") {
+        set req.url = regsuball(req.url, "(_branch_match_id|srsltid|_bta_c|_bta_tid|_ga|_gl|_ke|_kx|campid|cof|customid|cx|dclid|dm_i|ef_id|epik|fbclid|gad_source|gbraid|gclid|gclsrc|gdffi|gdfms|gdftrk|hsa_acc|hsa_ad|hsa_cam|hsa_grp|hsa_kw|hsa_mt|hsa_net|hsa_src|hsa_tgt|hsa_ver|ie|igshid|irclickid|matomo_campaign|matomo_cid|matomo_content|matomo_group|matomo_keyword|matomo_medium|matomo_placement|matomo_source|mc_cid|mc_eid|mkcid|mkevt|mkrid|mkwid|msclkid|mtm_campaign|mtm_cid|mtm_content|mtm_group|mtm_keyword|mtm_medium|mtm_placement|mtm_source|nb_klid|ndclid|origin|pcrid|piwik_campaign|piwik_keyword|piwik_kwd|pk_campaign|pk_keyword|pk_kwd|redirect_log_mongo_id|redirect_mongo_id|rtid|sb_referer_host|ScCid|si|siteurl|s_kwcid|sms_click|sms_source|sms_uph|toolid|trk_contact|trk_module|trk_msg|trk_sid|ttclid|twclid|utm_campaign|utm_content|utm_creative_format|utm_id|utm_marketing_tactic|utm_medium|utm_source|utm_source_platform|utm_term|wbraid|yclid|zanpid|mc_[a-z]+|utm_[a-z]+|_bta_[a-z]+)=[-_A-z0-9+(){}%.]+&?", "");
+        set req.url = regsub(req.url, "[?|&]+$", "");
+    }
+
+    # Media files caching
+    if (req.url ~ "^/(pub/)?media/") {
+        if ( 0 ) { # TODO MAKE CONFIGURABLE: Cache media files
+            unset req.http.Https;
+            unset req.http.{{var ssl_offloaded_header}};
+            unset req.http.Cookie;
+        } else {
+            return (pass);
+        }
+    }
+
+    # Static files caching
+    if (req.url ~ "^/(pub/)?static/") {
+        if ( 0 ) { # TODO MAKE CONFIGURABLE: Cache static files
+            unset req.http.Https;
+            unset req.http.{{var ssl_offloaded_header}};
+            unset req.http.Cookie;
+        } else {
+            return (pass);
+        }
+    }
+
+    # Don't cache the authenticated GraphQL requests
+    if (req.url ~ "/graphql" && req.http.Authorization ~ "^Bearer") {
+        return (pass);
+    }
+
+    return (hash);
+}
+
+sub vcl_hash {
+    if (req.url !~ "/graphql" && cookie.isset("X-Magento-Vary=")) {
+        hash_data(cookie.get("X-Magento-Vary"));
+    }
+
+    # To make sure http users don't see ssl warning
+    hash_data(req.http.{{var ssl_offloaded_header }});
+
+    {{var design_exceptions_code}}
+
+    if (req.url ~ "/graphql") {
+        call process_graphql_headers;
+    }
+}
+
+sub process_graphql_headers {
+    if (req.http.X-Magento-Cache-Id) {
+        hash_data(req.http.X-Magento-Cache-Id);
+
+        # When the frontend stops sending the auth token, make sure users stop getting results cached for logged-in users
+        if (req.http.Authorization ~ "^Bearer") {
+            hash_data("Authorized");
+        }
+    }
+
+    if (req.http.Store) {
+        hash_data(req.http.Store);
+    }
+
+    if (req.http.Content-Currency) {
+        hash_data(req.http.Content-Currency);
+    }
+}
+
+sub vcl_backend_response {
+    # Serve stale content for three days after object expiration
+    # Perform asynchronous revalidation while stale content is served
+    set beresp.grace = 1d;
+
+    if (beresp.http.X-Magento-Tags) {
+        # set comma separated xkey with "all" tag
+        set beresp.http.XKey = beresp.http.X-Magento-Tags + ",all";
+        unset beresp.http.X-Magento-Tags;
+    }
+
+    # All text-based content can be parsed as ESI
+    if (beresp.http.content-type ~ "text") {
+        set beresp.do_esi = true;
+    }
+
+    # Cache HTTP 200 responses
+    # TODO MAKE CONFIGURABLE whether or not 404's should be cached
+    if (beresp.status != 200 && beresp.status != 404) {
+    #if (beresp.status != 200) {
+        set beresp.ttl = 120s;
+        set beresp.uncacheable = true;
+        return (deliver);
+    }
+
+    # Don't cache if the request cache ID doesn't match the response cache ID for graphql requests
+    if (bereq.url ~ "/graphql" && bereq.http.X-Magento-Cache-Id && bereq.http.X-Magento-Cache-Id != beresp.http.X-Magento-Cache-Id) {
+       set beresp.ttl = 120s;
+       set beresp.uncacheable = true;
+       return (deliver);
+    }
+
+    # Remove the Set-Cookie header for cacheable content
+    # Only for HTTP GET & HTTP HEAD requests
+    if (beresp.ttl > 0s && (bereq.method == "GET" || bereq.method == "HEAD")) {
+        unset beresp.http.Set-Cookie;
+    }
+}
+
+sub vcl_deliver {
+    if (obj.uncacheable) {
+        set resp.http.X-Magento-Cache-Debug = "UNCACHEABLE";
+    } else if (obj.hits) {
+        set resp.http.X-Magento-Cache-Debug = "HIT";
+        set resp.http.Grace = req.http.grace;
+    } else {
+        set resp.http.X-Magento-Cache-Debug = "MISS";
+    }
+
+    # Let browser and Cloudflare cache non-static content that are cacheable for short period of time
+    if (resp.http.Cache-Control !~ "private" && req.url !~ "^/(media|static)/" && obj.ttl > 0s) {
+        set resp.http.Cache-Control = "must-revalidate, max-age=60";
+        if ( 0 ) { # TODO MAKE CONFIGURABLE: Enable/disable backward-forward cache (default enabled)
+            set resp.http.Cache-Control = resp.http.Cache-Control + ", no-store";
+        }
+    }
+
+    unset resp.http.XKey;
+    unset resp.http.Expires;
+    unset resp.http.Pragma;
+    unset resp.http.X-Magento-Debug;
+    unset resp.http.X-Magento-Tags;
+    unset resp.http.X-Powered-By;
+    unset resp.http.Server;
+    unset resp.http.X-Varnish;
+    unset resp.http.Via;
+    unset resp.http.Link;
+}


### PR DESCRIPTION
This will add support for very basic templating directives to improve VCL rendering. The directives supported now are: var, if and loop.

Fixes #19