### PR TITLE
Support HIT-GRACE output for the X-Magento-Cache-Debug header

### DIFF
--- a/etc/varnish6.vcl
+++ b/etc/varnish6.vcl
@@ -233,9 +233,10 @@ sub vcl_backend_response {
 sub vcl_deliver {
     if (obj.uncacheable) {
         set resp.http.X-Magento-Cache-Debug = "UNCACHEABLE";
-    } else if (obj.hits) {
+    } else if (obj.hits > 0 && obj.ttl > 0s) {
         set resp.http.X-Magento-Cache-Debug = "HIT";
-        set resp.http.Grace = req.http.grace;
+    } else if (obj.hits > 0 && obj.ttl <= 0s) {
+        set resp.http.X-Magento-Cache-Debug = "HIT-GRACE";
     } else {
         set resp.http.X-Magento-Cache-Debug = "MISS";
     }


### PR DESCRIPTION
If the `obj.hits` value is greater than zero, we know that the object is served from the cache. However, it is only a pure cache hit if the `obj.ttl` value is greater than zero.

Otherwise stale content is served as a cache hit, while an asynchronous fetch takes place. This is called a *graced hit*.

If this scenario takes place, we set the value of the `X-Magento-Cache-Debug` header to `HIT-GRACE`.