### PR TITLE
VCLGenerator: Handle empty access list

### DIFF
--- a/Model/Varnish/VCLGenerator.php
+++ b/Model/Varnish/VCLGenerator.php
@@ -88,6 +88,13 @@ class VCLGenerator extends \Magento\PageCache\Model\Varnish\VclGenerator
      */
     private function getTransformedAccessList(): array
     {
-        return array_map(fn ($x) => ['ip' => trim($x)], $this->accessList);
+        $result = [];
+        foreach ($this->accessList as $ip) {
+            $ip = trim($ip);
+            if (strlen($ip)) {
+                $result[] = ['ip' => $ip];
+            }
+        }
+        return $result;
     }
 }


### PR DESCRIPTION
If there's a `' '` configured or any empty configuration, we should not render them as entries..