### PR TITLE
Include test variables

### DIFF
--- a/tests/varnish/force_cache_refresh.vtc
+++ b/tests/varnish/force_cache_refresh.vtc
@@ -1,0 +1,94 @@
+varnishtest "Force cache refresh for whitelisted IP addresses"
+
+server s1 {
+    # first request will be the probe, handle it and be on our way
+    rxreq
+    expect req.url == "/health_check.php"
+    txresp
+
+    # the probe expects the connection to close
+    close
+    accept
+
+    rxreq
+    expect req.url == "/"
+    expect req.method == "GET"
+    txresp
+
+    rxreq
+    expect req.url == "/"
+    expect req.method == "GET"
+    txresp
+
+    rxreq
+    expect req.url == "/"
+    expect req.method == "GET"
+    txresp
+} -start
+
+# generate usable VCL pointing towards s1
+# mostly, we replace the place-holders, but we also jack up the probe
+# interval to avoid further interference
+shell {
+    # Backend configuration
+    export HOST="${s1_addr}"
+    export PORT="${s1_port}"
+    export GRACE_PERIOD="300"
+
+    # SSL configuration
+    export SSL_OFFLOADED_HEADER="X-Forwarded-Proto"
+
+    # Feature flags
+    export USE_XKEY_VMOD="1"
+    export ENABLE_MEDIA_CACHE="1"
+    export ENABLE_STATIC_CACHE="1"
+
+    # ACL list with IPs
+    export ACCESS_LIST="server1 server2"
+    export SERVER1_IP="${s1_addr}"
+    export SERVER2_IP="10.0.0.1"
+
+    # Cookie list with regex patterns
+    export PASS_ON_COOKIE_PRESENCE="cookie1 cookie2"
+    export COOKIE1_REGEX="^ADMIN"
+    export COOKIE2_REGEX="^PHPSESSID"
+
+    # Performance parameters
+    export TRACKING_PARAMETERS="utm_source|utm_medium|utm_campaign|gclid|cx|ie|cof|siteurl"
+
+    # Design exceptions
+    export DESIGN_EXCEPTIONS_CODE='if (req.url ~ "^/media/theme/") { hash_data("design1"); }'
+
+    ${testdir}/helpers/parse_vcl.pl "${testdir}/../../etc/varnish6.vcl" "${tmpdir}/output.vcl"
+}
+
+varnish v1 -arg "-f" -arg "${tmpdir}/output.vcl" -arg "-p" -arg "vsl_mask=+Hash" -start
+
+# make sure the probe request fired
+delay 1
+
+client c1 {
+    txreq -method "GET" -url "/"
+    rxresp
+    expect resp.http.X-Magento-Cache-Debug == "MISS"
+
+    txreq -method "GET" -url "/"
+    rxresp
+    expect resp.http.X-Magento-Cache-Debug == "HIT"
+
+    txreq -method "GET" -url "/" -hdr "pragma:no-cache"
+    rxresp
+    expect resp.http.X-Magento-Cache-Debug == "MISS-FORCED"
+
+    txreq -method "GET" -url "/"
+    rxresp
+    expect resp.http.X-Magento-Cache-Debug == "HIT"
+
+    txreq -method "GET" -url "/" -hdr "cache-control:no-cache"
+    rxresp
+    expect resp.http.X-Magento-Cache-Debug == "MISS-FORCED"
+
+    txreq -method "GET" -url "/"
+    rxresp
+    expect resp.http.X-Magento-Cache-Debug == "HIT"
+} -run

--- a/tests/varnish/force_cache_refresh.vtc
+++ b/tests/varnish/force_cache_refresh.vtc
@@ -26,39 +26,12 @@ server s1 {
     txresp
 } -start
 
-# generate usable VCL pointing towards s1
-# mostly, we replace the place-holders, but we also jack up the probe
-# interval to avoid further interference
+# Generate the VCL file based on included variables and write it to output.vcl
 shell {
-    # Backend configuration
+    . "${testdir}/helpers/parse_vcl_variables.sh"
     export HOST="${s1_addr}"
     export PORT="${s1_port}"
-    export GRACE_PERIOD="300"
-
-    # SSL configuration
-    export SSL_OFFLOADED_HEADER="X-Forwarded-Proto"
-
-    # Feature flags
-    export USE_XKEY_VMOD="1"
-    export ENABLE_MEDIA_CACHE="1"
-    export ENABLE_STATIC_CACHE="1"
-
-    # ACL list with IPs
-    export ACCESS_LIST="server1 server2"
     export SERVER1_IP="${s1_addr}"
-    export SERVER2_IP="10.0.0.1"
-
-    # Cookie list with regex patterns
-    export PASS_ON_COOKIE_PRESENCE="cookie1 cookie2"
-    export COOKIE1_REGEX="^ADMIN"
-    export COOKIE2_REGEX="^PHPSESSID"
-
-    # Performance parameters
-    export TRACKING_PARAMETERS="utm_source|utm_medium|utm_campaign|gclid|cx|ie|cof|siteurl"
-
-    # Design exceptions
-    export DESIGN_EXCEPTIONS_CODE='if (req.url ~ "^/media/theme/") { hash_data("design1"); }'
-
     ${testdir}/helpers/parse_vcl.pl "${testdir}/../../etc/varnish6.vcl" "${tmpdir}/output.vcl"
 }
 

--- a/tests/varnish/force_cache_refresh_invalid_ip.vtc
+++ b/tests/varnish/force_cache_refresh_invalid_ip.vtc
@@ -16,39 +16,12 @@ server s1 {
     txresp
 } -start
 
-# generate usable VCL pointing towards s1
-# mostly, we replace the place-holders, but we also jack up the probe
-# interval to avoid further interference
+# Generate the VCL file based on included variables and write it to output.vcl
 shell {
-    # Backend configuration
+    . "${testdir}/helpers/parse_vcl_variables.sh"
     export HOST="${s1_addr}"
     export PORT="${s1_port}"
-    export GRACE_PERIOD="300"
-
-    # SSL configuration
-    export SSL_OFFLOADED_HEADER="X-Forwarded-Proto"
-
-    # Feature flags
-    export USE_XKEY_VMOD="1"
-    export ENABLE_MEDIA_CACHE="1"
-    export ENABLE_STATIC_CACHE="1"
-
-    # ACL list with IPs
-    export ACCESS_LIST="server1 server2"
     export SERVER1_IP="10.0.0.1"
-    export SERVER2_IP="10.0.0.2"
-
-    # Cookie list with regex patterns
-    export PASS_ON_COOKIE_PRESENCE="cookie1 cookie2"
-    export COOKIE1_REGEX="^ADMIN"
-    export COOKIE2_REGEX="^PHPSESSID"
-
-    # Performance parameters
-    export TRACKING_PARAMETERS="utm_source|utm_medium|utm_campaign|gclid|cx|ie|cof|siteurl"
-
-    # Design exceptions
-    export DESIGN_EXCEPTIONS_CODE='if (req.url ~ "^/media/theme/") { hash_data("design1"); }'
-
     ${testdir}/helpers/parse_vcl.pl "${testdir}/../../etc/varnish6.vcl" "${tmpdir}/output.vcl"
 }
 

--- a/tests/varnish/force_cache_refresh_invalid_ip.vtc
+++ b/tests/varnish/force_cache_refresh_invalid_ip.vtc
@@ -1,0 +1,76 @@
+varnishtest "Don't perform forced cache refresh for non-whitelisted IP addresses"
+
+server s1 {
+    # first request will be the probe, handle it and be on our way
+    rxreq
+    expect req.url == "/health_check.php"
+    txresp
+
+    # the probe expects the connection to close
+    close
+    accept
+
+    rxreq
+    expect req.url == "/"
+    expect req.method == "GET"
+    txresp
+} -start
+
+# generate usable VCL pointing towards s1
+# mostly, we replace the place-holders, but we also jack up the probe
+# interval to avoid further interference
+shell {
+    # Backend configuration
+    export HOST="${s1_addr}"
+    export PORT="${s1_port}"
+    export GRACE_PERIOD="300"
+
+    # SSL configuration
+    export SSL_OFFLOADED_HEADER="X-Forwarded-Proto"
+
+    # Feature flags
+    export USE_XKEY_VMOD="1"
+    export ENABLE_MEDIA_CACHE="1"
+    export ENABLE_STATIC_CACHE="1"
+
+    # ACL list with IPs
+    export ACCESS_LIST="server1 server2"
+    export SERVER1_IP="10.0.0.1"
+    export SERVER2_IP="10.0.0.2"
+
+    # Cookie list with regex patterns
+    export PASS_ON_COOKIE_PRESENCE="cookie1 cookie2"
+    export COOKIE1_REGEX="^ADMIN"
+    export COOKIE2_REGEX="^PHPSESSID"
+
+    # Performance parameters
+    export TRACKING_PARAMETERS="utm_source|utm_medium|utm_campaign|gclid|cx|ie|cof|siteurl"
+
+    # Design exceptions
+    export DESIGN_EXCEPTIONS_CODE='if (req.url ~ "^/media/theme/") { hash_data("design1"); }'
+
+    ${testdir}/helpers/parse_vcl.pl "${testdir}/../../etc/varnish6.vcl" "${tmpdir}/output.vcl"
+}
+
+varnish v1 -arg "-f" -arg "${tmpdir}/output.vcl" -arg "-p" -arg "vsl_mask=+Hash" -start
+
+# make sure the probe request fired
+delay 1
+
+client c1 {
+    txreq -method "GET" -url "/"
+    rxresp
+    expect resp.http.X-Magento-Cache-Debug == "MISS"
+
+    txreq -method "GET" -url "/"
+    rxresp
+    expect resp.http.X-Magento-Cache-Debug == "HIT"
+
+    txreq -method "GET" -url "/" -hdr "pragma:no-cache"
+    rxresp
+    expect resp.http.X-Magento-Cache-Debug == "HIT"
+
+    txreq -method "GET" -url "/" -hdr "cache-control:no-cache"
+    rxresp
+    expect resp.http.X-Magento-Cache-Debug == "HIT"
+} -run

--- a/tests/varnish/helpers/parse_vcl_variables.sh
+++ b/tests/varnish/helpers/parse_vcl_variables.sh
@@ -1,0 +1,32 @@
+# generate usable VCL pointing towards s1
+# mostly, we replace the place-holders, but we also jack up the probe
+# interval to avoid further interference
+
+# Backend configuration
+export HOST="${s1_addr}"
+export PORT="${s1_port}"
+export GRACE_PERIOD="300"
+
+# SSL configuration
+export SSL_OFFLOADED_HEADER="X-Forwarded-Proto"
+
+# Feature flags
+export USE_XKEY_VMOD="1"
+export ENABLE_MEDIA_CACHE="1"
+export ENABLE_STATIC_CACHE="1"
+
+# ACL list with IPs
+export ACCESS_LIST="server1 server2"
+export SERVER1_IP="${s1_addr}"
+export SERVER2_IP="10.0.0.2"
+
+# Cookie list with regex patterns
+export PASS_ON_COOKIE_PRESENCE="cookie1 cookie2"
+export COOKIE1_REGEX="^ADMIN"
+export COOKIE2_REGEX="^PHPSESSID"
+
+# Performance parameters
+export TRACKING_PARAMETERS="utm_source|utm_medium|utm_campaign|gclid|cx|ie|cof|siteurl"
+
+# Design exceptions
+export DESIGN_EXCEPTIONS_CODE='if (req.url ~ "^/media/theme/") { hash_data("design1"); }'

--- a/tests/varnish/xkey.vtc
+++ b/tests/varnish/xkey.vtc
@@ -36,39 +36,12 @@ server s1 {
     txresp -hdr "X-Magento-Tags: cat_c,cat_c_37,cat_p_694,cat_c_21"
 } -start
 
-# generate usable VCL pointing towards s1
-# mostly, we replace the place-holders, but we also jack up the probe
-# interval to avoid further interference
+# Generate the VCL file based on included variables and write it to output.vcl
 shell {
-    # Backend configuration
+    . "${testdir}/helpers/parse_vcl_variables.sh"
     export HOST="${s1_addr}"
     export PORT="${s1_port}"
-    export GRACE_PERIOD="300"
-
-    # SSL configuration
-    export SSL_OFFLOADED_HEADER="X-Forwarded-Proto"
-
-    # Feature flags
-    export USE_XKEY_VMOD="1"
-    export ENABLE_MEDIA_CACHE="1"
-    export ENABLE_STATIC_CACHE="1"
-
-    # ACL list with IPs
-    export ACCESS_LIST="server1 server2"
     export SERVER1_IP="${s1_addr}"
-    export SERVER2_IP="10.0.0.1"
-
-    # Cookie list with regex patterns
-    export PASS_ON_COOKIE_PRESENCE="cookie1 cookie2"
-    export COOKIE1_REGEX="^ADMIN"
-    export COOKIE2_REGEX="^PHPSESSID"
-
-    # Performance parameters
-    export TRACKING_PARAMETERS="utm_source|utm_medium|utm_campaign|gclid|cx|ie|cof|siteurl"
-
-    # Design exceptions
-    export DESIGN_EXCEPTIONS_CODE='if (req.url ~ "^/media/theme/") { hash_data("design1"); }'
-
     ${testdir}/helpers/parse_vcl.pl "${testdir}/../../etc/varnish6.vcl" "${tmpdir}/output.vcl"
 }
 


### PR DESCRIPTION
Instead of loading the test variables to generate the VCL in every test case separately, we include them from a single variables file.

The `$HOST`, `$PORT` & `$SERVER1_IP` variables need to be set in each test case, because `${s1_addr}` & `${s1_port}` are not accessible in `parse_vcl_variables.sh`