### PR TITLE
Backward-forward cache edge cases + VCL optimization

### DIFF
--- a/etc/varnish6.vcl
+++ b/etc/varnish6.vcl
@@ -292,7 +292,7 @@ sub vcl_deliver {
     }
 
     # Let browser and Cloudflare cache non-static content that are cacheable for short period of time
-    if (resp.http.Cache-Control !~ "private" && req.url !~ "^/(media|static)/" && obj.ttl > 0s) {
+    if (resp.http.Cache-Control !~ "private" && req.url !~ "^/(media|static)/" && obj.ttl > 0s && !obj.uncacheable) {
 {{if enable_bfcache}}
         set resp.http.Cache-Control = "must-revalidate, max-age=60";
 {{else}}

--- a/tests/varnish/bfcache.vtc
+++ b/tests/varnish/bfcache.vtc
@@ -13,12 +13,32 @@ server s1 {
     rxreq
     expect req.url == "/"
     expect req.method == "GET"
-    txresp
+    txresp -hdr "Cache-Control: public, max-age=86400"
 
     rxreq
-    expect req.url == "/"
+    expect req.url == "/media/1"
     expect req.method == "GET"
-    txresp
+    txresp -hdr "Cache-Control: public, max-age=86400"
+
+    rxreq
+    expect req.url == "/static/1"
+    expect req.method == "GET"
+    txresp -hdr "Cache-Control: public, max-age=86400"
+
+    rxreq
+    expect req.url == "/1"
+    expect req.method == "GET"
+    txresp -hdr "Cache-Control: private, no-cache, no-store"
+
+    rxreq
+    expect req.url == "/2"
+    expect req.method == "GET"
+    txresp -hdr "Cache-Control: max-age=0"
+
+    rxreq
+    expect req.url == "/3"
+    expect req.method == "GET"
+    txresp -hdr "Cache-Control: public, max-age=3600, s-maxage=0"
 } -start
 
 # Generate the VCL file based on included variables and write it to output.vcl
@@ -36,8 +56,25 @@ delay 1
 client c1 {
     txreq -method "GET" -url "/"
     rxresp
-
-    txreq -method "GET" -url "/"
-    rxresp
     expect resp.http.Cache-Control == "must-revalidate, max-age=60"
+
+    txreq -method "GET" -url "/media/1"
+    rxresp
+    expect resp.http.Cache-Control == "public, max-age=86400"
+
+    txreq -method "GET" -url "/static/1"
+    rxresp
+    expect resp.http.Cache-Control == "public, max-age=86400"
+
+    txreq -method "GET" -url "/1"
+    rxresp
+    expect resp.http.Cache-Control == "private, no-cache, no-store"
+
+    txreq -method "GET" -url "/2"
+    rxresp
+    expect resp.http.Cache-Control == "max-age=0"
+
+    txreq -method "GET" -url "/3"
+    rxresp
+    expect resp.http.Cache-Control == "public, max-age=3600, s-maxage=0"
 } -run


### PR DESCRIPTION
Tested some of the backward-forward cache edge cases.

I also spotted a limitation to the `obj.ttl > 0s` check: uncacheable content will have a TTL of 120 seconds when it becomes "hit-for-miss". Added an extra `!obj.uncacheable` check for this.