### PR TITLE
Test purging & remove duplicate purge logic

### DIFF
--- a/etc/varnish6.vcl
+++ b/etc/varnish6.vcl
@@ -100,16 +100,9 @@ sub vcl_recv {
             return (synth(200, req.http.n-gone));
         }
 {{else}}
-        if (req.method == "PURGE") {
-            if (client.ip !~ purge) {
-                return (synth(405, "Method not allowed"));
-            }
-            if (!req.http.X-Magento-Tags-Pattern) {
-                return (purge);
-            }
-            ban("obj.http.X-Magento-Tags ~ " + req.http.X-Magento-Tags-Pattern);
-            return (synth(200, "0"));
-        }
+        ban("obj.http.X-Magento-Tags ~ " + req.http.X-Magento-Tags-Pattern);
+        return (synth(200, "0"));
+
 {{/if}}
     }
 

--- a/tests/varnish/purge.vtc
+++ b/tests/varnish/purge.vtc
@@ -46,6 +46,12 @@ varnish v1 -arg "-f" -arg "${tmpdir}/output.vcl" -arg "-p" -arg "vsl_mask=+Hash"
 # make sure the probe request fired
 delay 1
 
+# Capture the logs to check if the purge requests trigger a "return(purge)" in Varnish
+logexpect l1 -v v1 -g request -q "ReqMethod eq 'PURGE'" {
+    expect * 1005 VCL_return ^purge$
+    expect * 1009 VCL_return ^purge$
+}  -start
+
 client c1 {
     # filling the cache
     txreq -method "GET" -url "/" -hdr "Context: fill the cache"
@@ -90,3 +96,5 @@ client c1 {
     rxresp
     expect resp.http.X-Magento-Cache-Debug == "MISS"
 } -run
+
+logexpect l1 -wait

--- a/tests/varnish/purge.vtc
+++ b/tests/varnish/purge.vtc
@@ -1,0 +1,92 @@
+varnishtest "purge content based on the URL"
+
+server s1 {
+    # first request will be the probe, handle it and be on our way
+    rxreq
+    expect req.url == "/health_check.php"
+    txresp
+
+    # the probe expects the connection to close
+    close
+    accept
+
+    # Fill the cache
+    rxreq
+    expect req.url == "/"
+    expect req.method == "GET"
+    txresp -hdr "Context: fill the cache"
+
+    rxreq
+    expect req.url == "/hero-hoodie.html"
+    expect req.method == "GET"
+    txresp -hdr "Context: fill the cache"
+
+    # Cache miss after purge
+    rxreq
+    expect req.url == "/"
+    expect req.method == "GET"
+    txresp -hdr "Context: cache miss after purge for /"
+
+    # Cache miss after purge
+    rxreq
+    expect req.url == "/hero-hoodie.html"
+    expect req.method == "GET"
+    txresp -hdr "Context: cache miss after purge for /hero-hoodie.html"
+} -start
+
+# Generate the VCL file based on included variables and write it to output.vcl
+shell {
+    export s1_addr="${s1_addr}"
+    export s1_port="${s1_port}"
+    ${testdir}/helpers/parse_vcl.pl "${testdir}/../../etc/varnish6.vcl" "${tmpdir}/output.vcl"
+}
+
+varnish v1 -arg "-f" -arg "${tmpdir}/output.vcl" -arg "-p" -arg "vsl_mask=+Hash" -start
+
+# make sure the probe request fired
+delay 1
+
+client c1 {
+    # filling the cache
+    txreq -method "GET" -url "/" -hdr "Context: fill the cache"
+    rxresp
+    expect resp.http.X-Magento-Cache-Debug == "MISS"
+
+    txreq -method "GET" -url "/hero-hoodie.html" -hdr "Context: fill the cache"
+    rxresp
+    expect resp.http.X-Magento-Cache-Debug == "MISS"
+
+    # Purge "/"
+    txreq -method "PURGE" -url "/"
+    rxresp
+    expect resp.status == 200
+    expect resp.http.Content-Type == "application/json"
+    expect resp.body == "{ \"invalidated\": 1 }"
+    expect resp.reason == "OK"
+
+    txreq -method "GET" -url "/hero-hoodie.html" -hdr "Context: check hit after purge for /"
+    rxresp
+    expect resp.http.X-Magento-Cache-Debug == "HIT"
+
+    # Cache mis after purge
+    txreq -method "GET" -url "/" -hdr "Context: cache miss after purge"
+    rxresp
+    expect resp.http.X-Magento-Cache-Debug == "MISS"
+
+    # Purge "/"
+    txreq -method "PURGE" -url "/hero-hoodie.html"
+    rxresp
+    expect resp.status == 200
+    expect resp.http.Content-Type == "application/json"
+    expect resp.body == "{ \"invalidated\": 1 }"
+    expect resp.reason == "OK"
+
+    txreq -method "GET" -url "/" -hdr "Context: check hit after purge for /"
+    rxresp
+    expect resp.http.X-Magento-Cache-Debug == "HIT"
+
+    # Cache mis after purge
+    txreq -method "GET" -url "/hero-hoodie.html" -hdr "Context: cache miss after purge"
+    rxresp
+    expect resp.http.X-Magento-Cache-Debug == "MISS"
+} -run


### PR DESCRIPTION
These tests validate URL-based purging by not setting an `X-Magento-Tags-Pattern` header.

I also spotted some duplicate purging logic in the `use_xkey_vmod` templating code that I removed.