### PR TITLE
Test ban logic in case xkey is not available

### DIFF
--- a/tests/varnish/ban.vtc
+++ b/tests/varnish/ban.vtc
@@ -1,0 +1,94 @@
+varnishtest "ban: purge a tag"
+
+server s1 {
+    # first request will be the probe, handle it and be on our way
+    rxreq
+    expect req.url == "/health_check.php"
+    txresp
+
+    # the probe expects the connection to close
+    close
+    accept
+
+    # Fill the cache
+    rxreq
+    expect req.url == "/"
+    expect req.method == "GET"
+    txresp -hdr "X-Magento-Tags: cat_c,cat_c_38,cat_p_694,cat_c_20" -hdr "Context: fill the cache"
+
+    rxreq
+    expect req.url == "/hero-hoodie.html"
+    expect req.method == "GET"
+    txresp -hdr "X-Magento-Tags: cat_c,cat_c_37,cat_p_694,cat_c_21" -hdr "Context: fill the cache"
+
+    rxreq
+    expect req.url == "/breathe-easy-tank.html"
+    expect req.method == "GET"
+    txresp -hdr "X-Magento-Tags: cat_c,cat_c_37,cat_p_695,cat_c_21" -hdr "Context: fill the cache"
+
+    # ban cat_p_694
+    rxreq
+    expect req.url == "/"
+    expect req.method == "GET"
+    txresp -hdr "X-Magento-Tags: cat_c,cat_c_38,cat_p_694,cat_c_20" -hdr "Context: ban cat_p_694"
+
+    rxreq
+    expect req.url == "/hero-hoodie.html"
+    expect req.method == "GET"
+    txresp -hdr "X-Magento-Tags: cat_c,cat_c_37,cat_p_694,cat_c_21"  -hdr "Context: ban cat_p_694"
+} -start
+
+# Generate the VCL file based on included variables and write it to output.vcl
+shell {
+    export s1_addr="${s1_addr}"
+    export s1_port="${s1_port}"
+    export USE_XKEY_VMOD=0
+    ${testdir}/helpers/parse_vcl.pl "${testdir}/../../etc/varnish6.vcl" "${tmpdir}/output.vcl"
+}
+
+varnish v1 -arg "-f" -arg "${tmpdir}/output.vcl" -arg "-p" -arg "vsl_mask=+Hash"  -arg "-p" -arg "ban_lurker_age=3" -start
+
+# make sure the probe request fired
+delay 1
+
+client c1 {
+    # filling the cache
+    txreq -method "GET" -url "/" -hdr "Context: fill the cache"
+    rxresp
+    expect resp.http.X-Magento-Cache-Debug == "MISS"
+
+    txreq -method "GET" -url "/hero-hoodie.html" -hdr "Context: fill the cache"
+    rxresp
+    expect resp.http.X-Magento-Cache-Debug == "MISS"
+
+    txreq -method "GET" -url "/breathe-easy-tank.html" -hdr "Context: fill the cache"
+    rxresp
+    expect resp.http.X-Magento-Cache-Debug == "MISS"
+
+    # ban that affects "/" & "/hero-hoodie.html"
+    txreq -method "PURGE" -url "/" -hdr "X-Magento-Tags-Pattern: ((^|,)cat_p_694(,|$))"
+    rxresp
+    expect resp.status == 200
+    expect resp.http.Content-Type == "application/json"
+    expect resp.body == "{ \"invalidated\": 0 }"
+    expect resp.reason == "OK"
+} -run
+
+# Checking the ban list
+varnish v1 -cliexpect "obj.http.X-Magento-Tags \\~ \\(\\(\\^\\|,\\)cat_p_694\\(,\\|\\$\\)\\)" ban.list
+
+client c1 {
+    # ban cause cache misses
+    txreq -method "GET" -url "/" -hdr "Context: ban cat_p_694"
+    rxresp
+    expect resp.http.X-Magento-Cache-Debug == "MISS"
+
+    txreq -method "GET" -url "/hero-hoodie.html" -hdr "Context: ban cat_p_694"
+    rxresp
+    expect resp.http.X-Magento-Cache-Debug == "MISS"
+
+    # "/breathe-easy-tank.html" is unaffected
+    txreq -method "GET" -url "/breathe-easy-tank.html" -hdr "Context: ban cat_p_694"
+    rxresp
+    expect resp.http.X-Magento-Cache-Debug == "HIT"
+} -run

--- a/tests/varnish/ban_all.vtc
+++ b/tests/varnish/ban_all.vtc
@@ -1,0 +1,98 @@
+varnishtest "ban: purge a tag"
+
+server s1 {
+    # first request will be the probe, handle it and be on our way
+    rxreq
+    expect req.url == "/health_check.php"
+    txresp
+
+    # the probe expects the connection to close
+    close
+    accept
+
+    # Fill the cache
+    rxreq
+    expect req.url == "/"
+    expect req.method == "GET"
+    txresp -hdr "X-Magento-Tags: cat_c,cat_c_38,cat_p_694,cat_c_20" -hdr "Context: fill the cache"
+
+    rxreq
+    expect req.url == "/hero-hoodie.html"
+    expect req.method == "GET"
+    txresp -hdr "X-Magento-Tags: cat_c,cat_c_37,cat_p_694,cat_c_21" -hdr "Context: fill the cache"
+
+    rxreq
+    expect req.url == "/breathe-easy-tank.html"
+    expect req.method == "GET"
+    txresp -hdr "X-Magento-Tags: cat_c,cat_c_37,cat_p_695,cat_c_21" -hdr "Context: fill the cache"
+
+    # ban all
+    rxreq
+    expect req.url == "/"
+    expect req.method == "GET"
+    txresp -hdr "X-Magento-Tags: cat_c,cat_c_38,cat_p_694,cat_c_20" -hdr "Context: ban all"
+
+    rxreq
+    expect req.url == "/hero-hoodie.html"
+    expect req.method == "GET"
+    txresp -hdr "X-Magento-Tags: cat_c,cat_c_37,cat_p_694,cat_c_21"  -hdr "Context: ban all"
+
+    rxreq
+    expect req.url == "/breathe-easy-tank.html"
+    expect req.method == "GET"
+    txresp -hdr "X-Magento-Tags: cat_c,cat_c_37,cat_p_695,cat_c_21" -hdr "Context: ban all"
+} -start
+
+# Generate the VCL file based on included variables and write it to output.vcl
+shell {
+    export s1_addr="${s1_addr}"
+    export s1_port="${s1_port}"
+    export USE_XKEY_VMOD=0
+    ${testdir}/helpers/parse_vcl.pl "${testdir}/../../etc/varnish6.vcl" "${tmpdir}/output.vcl"
+}
+
+varnish v1 -arg "-f" -arg "${tmpdir}/output.vcl" -arg "-p" -arg "vsl_mask=+Hash"  -arg "-p" -arg "ban_lurker_age=3" -start
+
+# make sure the probe request fired
+delay 1
+
+client c1 {
+    # filling the cache
+    txreq -method "GET" -url "/" -hdr "Context: fill the cache"
+    rxresp
+    expect resp.http.X-Magento-Cache-Debug == "MISS"
+
+    txreq -method "GET" -url "/hero-hoodie.html" -hdr "Context: fill the cache"
+    rxresp
+    expect resp.http.X-Magento-Cache-Debug == "MISS"
+
+    txreq -method "GET" -url "/breathe-easy-tank.html" -hdr "Context: fill the cache"
+    rxresp
+    expect resp.http.X-Magento-Cache-Debug == "MISS"
+
+    # ban that affects all objects
+    txreq -method "PURGE" -url "/" -hdr "X-Magento-Tags-Pattern: .*"
+    rxresp
+    expect resp.status == 200
+    expect resp.http.Content-Type == "application/json"
+    expect resp.body == "{ \"invalidated\": 0 }"
+    expect resp.reason == "OK"
+} -run
+
+# Checking the ban list
+varnish v1 -cliexpect "obj.http.X-Magento-Tags \\~ \\.\\*" ban.list
+
+client c1 {
+    # ban cause cache misses
+    txreq -method "GET" -url "/" -hdr "Context: ban all"
+    rxresp
+    expect resp.http.X-Magento-Cache-Debug == "MISS"
+
+    txreq -method "GET" -url "/hero-hoodie.html" -hdr "Context: ban all"
+    rxresp
+    expect resp.http.X-Magento-Cache-Debug == "MISS"
+
+    txreq -method "GET" -url "/breathe-easy-tank.html" -hdr "Context: ban all"
+    rxresp
+    expect resp.http.X-Magento-Cache-Debug == "MISS"
+} -run


### PR DESCRIPTION
If `vmod_xkey` is not enabled on the system, we set the `USE_XKEY_VMOD` environment variable to `0` and fall back on the `ban()` function that Varnish offers natively.

This means there are no soft purges and no native tag-base cache invalidation.

In this test I'm also running a `varnishadm ban.list` command to check whether the ban made it to the ban list. By setting the `ban_lurker_age` runtime parameter to `0` in this test, bans get processed immediately.