### PR TITLE
Testing ACL enforcement with invalid purge IP

### DIFF
--- a/tests/varnish/acl.vtc
+++ b/tests/varnish/acl.vtc
@@ -1,0 +1,38 @@
+varnishtest "Don't perform forced cache refresh for non-whitelisted IP addresses"
+
+server s1 {
+    # first request will be the probe, handle it and be on our way
+    rxreq
+    expect req.url == "/health_check.php"
+    txresp
+} -start
+
+# Generate the VCL file based on included variables and write it to output.vcl
+shell {
+    export SERVER1_IP="10.0.0.1"
+    export s1_addr="${s1_addr}"
+    export s1_port="${s1_port}"
+    ${testdir}/helpers/parse_vcl.pl "${testdir}/../../etc/varnish6.vcl" "${tmpdir}/output.vcl"
+}
+
+varnish v1 -arg "-f" -arg "${tmpdir}/output.vcl" -arg "-p" -arg "vsl_mask=+Hash" -start
+
+# make sure the probe request fired
+delay 1
+
+client c1 {
+    # test URL-based cache purge
+    txreq -method "PURGE" -url "/"
+    rxresp
+    expect resp.status == 405
+
+    # test tag-based invalidation
+    txreq -method "PURGE" -url "/"  -hdr "X-Magento-Tags-Pattern: ((^|,)cat_p_694(,|$))"
+    rxresp
+    expect resp.status == 405
+
+    # test full cache purge
+    txreq -method "PURGE" -url "/"  -hdr "X-Magento-Tags-Pattern: .*"
+    rxresp
+    expect resp.status == 405
+} -run


### PR DESCRIPTION
Testing the enforcement of the `acl purge` for the following invalidation scenarios:

- Regular URL-based cache purge
- Tag-based cache invalidation
- A full cache purge