### PR TITLE
fix vcl and adds media and static cache tests

### DIFF
--- a/tests/varnish/media_files_cached.vtc
+++ b/tests/varnish/media_files_cached.vtc
@@ -1,0 +1,57 @@
+varnishtest "Media files are cached when enable_media_cache is true"
+
+server s1 {
+    # first request will be the probe, handle it and be on our way
+    rxreq
+    expect req.url == "/health_check.php"
+    txresp
+    
+    # the probe expects the connection to close
+    close
+    accept
+    
+    # Request for media file
+    rxreq
+    expect req.url == "/media/catalog/product/cache/1/image/265x265/beff4985b56e3afdbeabfc89641a4582/l/u/luma-yoga-jacket.jpg"
+    expect req.method == "GET"
+    txresp -hdr "Content-Type: image/jpeg" -body "JPEG image data"
+    
+    # Second request for the same media file should be served from cache
+    # This request should not reach the backend if caching is enabled
+} -start
+
+# Generate the VCL file with enable_media_cache=true
+shell {
+    export s1_addr="${s1_addr}"
+    export s1_port="${s1_port}"
+    export ENABLE_MEDIA_CACHE="1"
+    ${testdir}/helpers/parse_vcl.pl "${testdir}/../../etc/varnish6.vcl" "${tmpdir}/output.vcl"
+}
+
+varnish v1 -arg "-f" -arg "${tmpdir}/output.vcl" -arg "-p" -arg "vsl_mask=+Hash" -start
+
+# make sure the probe request fired
+delay 1
+
+client c1 {
+    # First request for media file
+    txreq -method "GET" -url "/media/catalog/product/cache/1/image/265x265/beff4985b56e3afdbeabfc89641a4582/l/u/luma-yoga-jacket.jpg" -hdr "Host: example.com"
+    rxresp
+    expect resp.http.X-Magento-Cache-Debug == "MISS"
+    expect resp.http.Content-Type == "image/jpeg"
+    expect resp.body == "JPEG image data"
+    
+    # Second request for the same media file should be served from cache
+    txreq -method "GET" -url "/media/catalog/product/cache/1/image/265x265/beff4985b56e3afdbeabfc89641a4582/l/u/luma-yoga-jacket.jpg" -hdr "Host: example.com"
+    rxresp
+    expect resp.http.X-Magento-Cache-Debug == "HIT"
+    expect resp.http.Content-Type == "image/jpeg"
+    expect resp.body == "JPEG image data"
+    
+    # Request with cookie should still be cached for media files
+    txreq -method "GET" -url "/media/catalog/product/cache/1/image/265x265/beff4985b56e3afdbeabfc89641a4582/l/u/luma-yoga-jacket.jpg" -hdr "Host: example.com" -hdr "Cookie: PHPSESSID=123456789"
+    rxresp
+    expect resp.http.X-Magento-Cache-Debug == "HIT"
+    expect resp.http.Content-Type == "image/jpeg"
+    expect resp.body == "JPEG image data"
+} -run

--- a/tests/varnish/media_files_not_cached.vtc
+++ b/tests/varnish/media_files_not_cached.vtc
@@ -1,0 +1,68 @@
+varnishtest "Media files are not cached when enable_media_cache is false"
+
+server s1 {
+    # first request will be the probe, handle it and be on our way
+    rxreq
+    expect req.url == "/health_check.php"
+    txresp
+    
+    # the probe expects the connection to close
+    close
+    accept
+    
+    # First request for media file
+    rxreq
+    expect req.url == "/media/catalog/product/cache/1/image/265x265/beff4985b56e3afdbeabfc89641a4582/l/u/luma-yoga-jacket.jpg"
+    expect req.method == "GET"
+    txresp -hdr "Content-Type: image/jpeg" -body "JPEG image data - first request"
+    
+    # Second request for the same media file should also reach the backend
+    # because caching is disabled for media files
+    rxreq
+    expect req.url == "/media/catalog/product/cache/1/image/265x265/beff4985b56e3afdbeabfc89641a4582/l/u/luma-yoga-jacket.jpg"
+    expect req.method == "GET"
+    txresp -hdr "Content-Type: image/jpeg" -body "JPEG image data - second request"
+    
+    # Request with cookie should also reach the backend
+    rxreq
+    expect req.url == "/media/catalog/product/cache/1/image/265x265/beff4985b56e3afdbeabfc89641a4582/l/u/luma-yoga-jacket.jpg"
+    expect req.method == "GET"
+    expect req.http.cookie == "PHPSESSID=123456789"
+    txresp -hdr "Content-Type: image/jpeg" -body "JPEG image data - with cookie"
+} -start
+
+# Generate the VCL file with enable_media_cache=false
+shell {
+    export s1_addr="${s1_addr}"
+    export s1_port="${s1_port}"
+    export ENABLE_MEDIA_CACHE="0"
+    ${testdir}/helpers/parse_vcl.pl "${testdir}/../../etc/varnish6.vcl" "${tmpdir}/output.vcl"
+}
+
+varnish v1 -arg "-f" -arg "${tmpdir}/output.vcl" -arg "-p" -arg "vsl_mask=+Hash" -start
+
+# make sure the probe request fired
+delay 1
+
+client c1 {
+    # First request for media file
+    txreq -method "GET" -url "/media/catalog/product/cache/1/image/265x265/beff4985b56e3afdbeabfc89641a4582/l/u/luma-yoga-jacket.jpg" -hdr "Host: example.com"
+    rxresp
+    expect resp.http.X-Magento-Cache-Debug == "UNCACHEABLE"
+    expect resp.http.Content-Type == "image/jpeg"
+    expect resp.body == "JPEG image data - first request"
+    
+    # Second request for the same media file should not be cached
+    txreq -method "GET" -url "/media/catalog/product/cache/1/image/265x265/beff4985b56e3afdbeabfc89641a4582/l/u/luma-yoga-jacket.jpg" -hdr "Host: example.com"
+    rxresp
+    expect resp.http.X-Magento-Cache-Debug == "UNCACHEABLE"
+    expect resp.http.Content-Type == "image/jpeg"
+    expect resp.body == "JPEG image data - second request"
+    
+    # Request with cookie should also not be cached
+    txreq -method "GET" -url "/media/catalog/product/cache/1/image/265x265/beff4985b56e3afdbeabfc89641a4582/l/u/luma-yoga-jacket.jpg" -hdr "Host: example.com" -hdr "Cookie: PHPSESSID=123456789"
+    rxresp
+    expect resp.http.X-Magento-Cache-Debug == "UNCACHEABLE"
+    expect resp.http.Content-Type == "image/jpeg"
+    expect resp.body == "JPEG image data - with cookie"
+} -run

--- a/tests/varnish/static_files_cached.vtc
+++ b/tests/varnish/static_files_cached.vtc
@@ -1,0 +1,57 @@
+varnishtest "Static files are cached when enable_static_cache is true"
+
+server s1 {
+    # first request will be the probe, handle it and be on our way
+    rxreq
+    expect req.url == "/health_check.php"
+    txresp
+    
+    # the probe expects the connection to close
+    close
+    accept
+    
+    # Request for static file
+    rxreq
+    expect req.url == "/static/version1234/frontend/Magento/luma/en_US/css/styles.css"
+    expect req.method == "GET"
+    txresp -hdr "Content-Type: text/css" -body "/* CSS styles */"
+    
+    # Second request for the same static file should be served from cache
+    # This request should not reach the backend if caching is enabled
+} -start
+
+# Generate the VCL file with enable_static_cache=true
+shell {
+    export s1_addr="${s1_addr}"
+    export s1_port="${s1_port}"
+    export ENABLE_STATIC_CACHE="1"
+    ${testdir}/helpers/parse_vcl.pl "${testdir}/../../etc/varnish6.vcl" "${tmpdir}/output.vcl"
+}
+
+varnish v1 -arg "-f" -arg "${tmpdir}/output.vcl" -arg "-p" -arg "vsl_mask=+Hash" -start
+
+# make sure the probe request fired
+delay 1
+
+client c1 {
+    # First request for static file
+    txreq -method "GET" -url "/static/version1234/frontend/Magento/luma/en_US/css/styles.css" -hdr "Host: example.com"
+    rxresp
+    expect resp.http.X-Magento-Cache-Debug == "MISS"
+    expect resp.http.Content-Type == "text/css"
+    expect resp.body == "/* CSS styles */"
+    
+    # Second request for the same static file should be served from cache
+    txreq -method "GET" -url "/static/version1234/frontend/Magento/luma/en_US/css/styles.css" -hdr "Host: example.com"
+    rxresp
+    expect resp.http.X-Magento-Cache-Debug == "HIT"
+    expect resp.http.Content-Type == "text/css"
+    expect resp.body == "/* CSS styles */"
+    
+    # Request with cookie should still be cached for static files
+    txreq -method "GET" -url "/static/version1234/frontend/Magento/luma/en_US/css/styles.css" -hdr "Host: example.com" -hdr "Cookie: PHPSESSID=123456789"
+    rxresp
+    expect resp.http.X-Magento-Cache-Debug == "HIT"
+    expect resp.http.Content-Type == "text/css"
+    expect resp.body == "/* CSS styles */"
+} -run

--- a/tests/varnish/static_files_not_cached.vtc
+++ b/tests/varnish/static_files_not_cached.vtc
@@ -1,0 +1,68 @@
+varnishtest "Static files are not cached when enable_static_cache is false"
+
+server s1 {
+    # first request will be the probe, handle it and be on our way
+    rxreq
+    expect req.url == "/health_check.php"
+    txresp
+    
+    # the probe expects the connection to close
+    close
+    accept
+    
+    # First request for static file
+    rxreq
+    expect req.url == "/static/version1234/frontend/Magento/luma/en_US/css/styles.css"
+    expect req.method == "GET"
+    txresp -hdr "Content-Type: text/css" -body "/* CSS styles - first request */"
+    
+    # Second request for the same static file should also reach the backend
+    # because caching is disabled for static files
+    rxreq
+    expect req.url == "/static/version1234/frontend/Magento/luma/en_US/css/styles.css"
+    expect req.method == "GET"
+    txresp -hdr "Content-Type: text/css" -body "/* CSS styles - second request */"
+    
+    # Request with cookie should also reach the backend
+    rxreq
+    expect req.url == "/static/version1234/frontend/Magento/luma/en_US/css/styles.css"
+    expect req.method == "GET"
+    expect req.http.cookie == "PHPSESSID=123456789"
+    txresp -hdr "Content-Type: text/css" -body "/* CSS styles - with cookie */"
+} -start
+
+# Generate the VCL file with enable_static_cache=false
+shell {
+    export s1_addr="${s1_addr}"
+    export s1_port="${s1_port}"
+    export ENABLE_STATIC_CACHE="0"
+    ${testdir}/helpers/parse_vcl.pl "${testdir}/../../etc/varnish6.vcl" "${tmpdir}/output.vcl"
+}
+
+varnish v1 -arg "-f" -arg "${tmpdir}/output.vcl" -arg "-p" -arg "vsl_mask=+Hash" -start
+
+# make sure the probe request fired
+delay 1
+
+client c1 {
+    # First request for static file
+    txreq -method "GET" -url "/static/version1234/frontend/Magento/luma/en_US/css/styles.css" -hdr "Host: example.com"
+    rxresp
+    expect resp.http.X-Magento-Cache-Debug == "UNCACHEABLE"
+    expect resp.http.Content-Type == "text/css"
+    expect resp.body == "/* CSS styles - first request */"
+    
+    # Second request for the same static file should not be cached
+    txreq -method "GET" -url "/static/version1234/frontend/Magento/luma/en_US/css/styles.css" -hdr "Host: example.com"
+    rxresp
+    expect resp.http.X-Magento-Cache-Debug == "UNCACHEABLE"
+    expect resp.http.Content-Type == "text/css"
+    expect resp.body == "/* CSS styles - second request */"
+    
+    # Request with cookie should also not be cached
+    txreq -method "GET" -url "/static/version1234/frontend/Magento/luma/en_US/css/styles.css" -hdr "Host: example.com" -hdr "Cookie: PHPSESSID=123456789"
+    rxresp
+    expect resp.http.X-Magento-Cache-Debug == "UNCACHEABLE"
+    expect resp.http.Content-Type == "text/css"
+    expect resp.body == "/* CSS styles - with cookie */"
+} -run


### PR DESCRIPTION
@ThijsFeryn I had to move these 2 before cookie collection since:

- removing req.http.cookie still made cookies present in req (I think because of the cookie vmod)
- adding cookie.clean() https://varnish-cache.org/docs/trunk/reference/vmod_cookie.html#void-clean - did not make a difference