### PR TITLE
Remove platform from Docker command.

### DIFF
--- a/tests/varnish/Makefile
+++ b/tests/varnish/Makefile
@@ -1,9 +1,9 @@
 test:
-	docker run --platform linux/amd64 --rm --name varnishtest -v  ${PWD}/../../etc/varnish6.vcl:/magento/etc/varnish6.vcl -v  ${PWD}:/magento/tests/varnish -w /magento/tests/varnish/ varnish:fresh sh -c "/usr/bin/varnishtest -j 10 *.vtc"
+	docker run --rm --name varnishtest -v  ${PWD}/../../etc/varnish6.vcl:/magento/etc/varnish6.vcl -v  ${PWD}:/magento/tests/varnish -w /magento/tests/varnish/ varnish:latest sh -c "/usr/bin/varnishtest -j 10 *.vtc"
 
 test_single:
 	@if [ -z "$(TEST)" ]; then \
 		echo "Usage: make test-single TEST=<test-file-name>.vtc"; \
 		exit 1; \
 	fi
-	docker run --platform linux/amd64 --rm --name varnishtest -v  ${PWD}/../../etc/varnish6.vcl:/magento/etc/varnish6.vcl -v  ${PWD}:/magento/tests/varnish -w /magento/tests/varnish/ varnish:7.7 sh -c "/usr/bin/varnishtest $(TEST)"
+	docker run --rm --name varnishtest -v  ${PWD}/../../etc/varnish6.vcl:/magento/etc/varnish6.vcl -v  ${PWD}:/magento/tests/varnish -w /magento/tests/varnish/ varnish:latest sh -c "/usr/bin/varnishtest $(TEST)"


### PR DESCRIPTION
Varnish now also supports ARM. Binding to a specific platform is no longer required.